### PR TITLE
feat: migrate HelixUI to v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@storybook/addons": "^5.3.17",
     "@storybook/react": "^5.3.17",
     "babel-loader": "^8.1.0",
-    "helix-ui": "^0.24.0",
+    "helix-ui": "^2.0.0",
     "husky": "^4.2.5",
     "microbundle": "^0.12.3",
     "prettier": "^2.0.4",
@@ -68,7 +68,7 @@
     "use-onclickoutside": "^0.3"
   },
   "peerDependencies": {
-    "helix-ui": "^0.24.0",
+    "helix-ui": "^2.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.6.3"
   },

--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -1,18 +1,23 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import useEventListener from '../hooks/useEventListener';
+import useCombinedRefs from '../hooks/useCombinedRefs';
 
-const Alert = ({ onOpen, onClose, className, children, onDismiss, onSubmit, ...rest }) => {
-  const hxRef = useEventListener({ onDismiss, onSubmit });
-  return (
-    <div>
-      {/* Wrappping element needed: Otherwise when alert removes itself from DOM on close, it will cause error */}
-      <hx-alert class={className} ref={hxRef} {...rest}>
-        {children}
-      </hx-alert>
-    </div>
-  );
-};
+const Alert = React.forwardRef(
+  ({ onOpen, onClose, className, children, onDismiss, onSubmit, ...rest }, ref) => {
+    const hxRef = useEventListener({ onDismiss, onSubmit }, ref);
+    return (
+      <div>
+        {/* Wrappping element needed: Otherwise when alert removes itself from DOM on close, it will cause error */}
+        <hx-alert class={className} ref={hxRef} {...rest}>
+          {children}
+        </hx-alert>
+      </div>
+    );
+  }
+);
+
+Alert.displayName = 'Alert';
 
 Alert.propTypes = {
   className: PropTypes.string,

--- a/src/Breadcrumb/index.js
+++ b/src/Breadcrumb/index.js
@@ -8,7 +8,7 @@ const Breadcrumb = ({ children, icon = 'angle-right', addDelimiter = true, ...re
       ? children.map((child, index) => [
           child,
           addDelimiter && index + 1 < children.length && (
-            <hx-icon key={index} class="delimiter" type={icon}></hx-icon>
+            <hx-icon key={index} class="delimiter" type={icon} />
           ),
         ])
       : children;

--- a/src/Breadcrumb/index.js
+++ b/src/Breadcrumb/index.js
@@ -8,7 +8,7 @@ const Breadcrumb = ({ children, icon = 'angle-right', addDelimiter = true, ...re
       ? children.map((child, index) => [
           child,
           addDelimiter && index + 1 < children.length && (
-            <hx-icon class="delimiter" type={icon}></hx-icon>
+            <hx-icon key={index} class="delimiter" type={icon}></hx-icon>
           ),
         ])
       : children;

--- a/src/Breadcrumb/index.js
+++ b/src/Breadcrumb/index.js
@@ -22,7 +22,7 @@ const Breadcrumb = ({ children, icon = 'angle-right', addDelimiter = true, ...re
 
 Breadcrumb.propTypes = {
   icon: PropTypes.string,
-  children: PropTypes.func,
+  children: PropTypes.node,
 };
 
 export default Breadcrumb;

--- a/src/Breadcrumb/stories.js
+++ b/src/Breadcrumb/stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { addParameters, storiesOf } from '@storybook/react';
+import { text } from '@storybook/addon-knobs/react';
 import Breadcrumb from './index';
 
 addParameters({
@@ -8,18 +9,22 @@ addParameters({
 
 storiesOf('Breadcrumb', module)
   .add('Multiple Breadcrumbs', () => {
+    let item1 = text('item1', 'Home');
+    let item2 = text('item2', 'Library');
+    let item3 = text('item3', 'Current');
     return (
       <Breadcrumb>
-        <a href="#">Home</a>
-        <a href="#">Library</a>
-        <a href="#">Current</a>
+        <a href="#">{item1}</a>
+        <a href="#">{item2}</a>
+        <a href="#">{item3}</a>
       </Breadcrumb>
     );
   })
   .add('Single Breadcrumb', () => {
+    let item1 = text('item1', 'Home');
     return (
       <Breadcrumb>
-        <a href="#">Home</a>
+        <a href="#">{item1}</a>
       </Breadcrumb>
     );
   });

--- a/src/Busy/index.js
+++ b/src/Busy/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 // Storybook story lives in /Progress folder
 const Busy = ({ className, children, ...rest }) => {
-  return <hx-busy class={className} {...rest}></hx-busy>;
+  return <hx-busy class={className} {...rest} />;
 };
 
 Busy.propTypes = {

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../Icon';
+import Busy from '../Busy';
 
 function cssFor(modifier) {
   return {
@@ -34,7 +35,7 @@ class Button extends React.Component {
       <button className={classNames(this.props)} type={type || 'button'} {...props}>
         {headIcon && <Icon type={headIcon} />}
         {children && <span>{children}</span>}
-        {busy ? <hx-busy></hx-busy> : tailIcon && <Icon type={tailIcon} />}
+        {busy ? <Busy />: tailIcon && <Icon type={tailIcon} />}
       </button>
     );
   }

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -35,7 +35,7 @@ class Button extends React.Component {
       <button className={classNames(this.props)} type={type || 'button'} {...props}>
         {headIcon && <Icon type={headIcon} />}
         {children && <span>{children}</span>}
-        {busy ? <Busy />: tailIcon && <Icon type={tailIcon} />}
+        {busy ? <Busy /> : tailIcon && <Icon type={tailIcon} />}
       </button>
     );
   }

--- a/src/Button/stories.js
+++ b/src/Button/stories.js
@@ -10,24 +10,25 @@ addParameters({
 });
 
 const SIZES = {
-  small: 'Small',
-  '': 'Medium',
-  large: 'Large',
+  small: 'small',
+  medium: 'medium',
+  large: 'large',
 };
+
 const VARIANTS = {
-  primary: 'Primary',
-  '': 'Secondary',
-  tertiary: 'Tertiary',
+  primary: 'primary',
+  secondary: 'secondary',
+  tertiary: 'tertiary',
 };
 
 storiesOf('Button', module)
   .addDecorator(centered)
   .add('Sizes', () => {
-    const size = select('size', SIZES, '');
+    const size = select('size', SIZES, 'medium');
     return <Button {...(size && { size })}>{SIZES[size]} Button</Button>;
   })
   .add('Variants', () => {
-    const variant = select('variant', VARIANTS, '');
+    const variant = select('variant', VARIANTS, 'primary');
     return <Button {...(variant && { variant })}>{VARIANTS[variant]} Button</Button>;
   })
   .add('Icon Only', () => {

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef(
       <hx-checkbox-control class={className}>
         <input ref={hxRef} {...rest} id={id} type="checkbox" />
         <label htmlFor={id}>
-          <hx-checkbox></hx-checkbox>
+          <hx-checkbox />
           {label}
         </label>
       </hx-checkbox-control>

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -1,22 +1,27 @@
 import PropTypes from 'prop-types';
 import React, { useRef, useEffect } from 'react';
+import useCombinedRefs from '../hooks/useCombinedRefs';
 
-const Checkbox = ({ id, label, indeterminate, className, style, ...rest }) => {
-  const inputRef = useRef();
-  useEffect(() => {
-    inputRef.current.indeterminate = indeterminate;
-  }, [indeterminate]);
+const Checkbox = React.forwardRef(
+  ({ id, label, indeterminate, className, style, ...rest }, ref) => {
+    const hxRef = useCombinedRefs(ref, useRef());
+    useEffect(() => {
+      hxRef.current.indeterminate = indeterminate;
+    }, [indeterminate]);
 
-  return (
-    <hx-checkbox-control class={className}>
-      <input ref={inputRef} {...rest} id={id} type="checkbox" />
-      <label htmlFor={id}>
-        <hx-checkbox></hx-checkbox>
-        {label}
-      </label>
-    </hx-checkbox-control>
-  );
-};
+    return (
+      <hx-checkbox-control class={className}>
+        <input ref={hxRef} {...rest} id={id} type="checkbox" />
+        <label htmlFor={id}>
+          <hx-checkbox></hx-checkbox>
+          {label}
+        </label>
+      </hx-checkbox-control>
+    );
+  }
+);
+
+Checkbox.displayName = 'Checkbox';
 
 Checkbox.propTypes = {
   className: PropTypes.string,

--- a/src/ChoiceTile/index.js
+++ b/src/ChoiceTile/index.js
@@ -58,7 +58,7 @@ ChoiceTile.propTypes = {
   disabled: PropTypes.bool,
   icon: PropTypes.string,
   invalid: PropTypes.bool,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   onChange: PropTypes.func,
   size: PropTypes.oneOf(Object.keys(SIZES)),
   subdued: PropTypes.bool,

--- a/src/ChoiceTile/index.js
+++ b/src/ChoiceTile/index.js
@@ -18,19 +18,24 @@ const ChoiceTile = ({
   subdued,
   title,
   style,
+  radioInput,
   ...rest
 }) => {
   return (
     <label className={classNames({ hxChoice: true }, className)} style={style}>
-      <input
-        checked={wcBool(checked)}
-        disabled={disabled}
-        invalid={invalid?.toString()}
-        name={name}
-        onChange={onChange}
-        type="radio"
-        {...rest}
-      />
+      {radioInput ? (
+        radioInput
+      ) : (
+        <input
+          checked={wcBool(checked)}
+          disabled={disabled}
+          invalid={invalid?.toString()}
+          name={name}
+          onChange={onChange}
+          type="radio"
+          {...rest}
+        />
+      )}
       <hx-tile class={classNames({ hxSubdued: subdued, [SIZES[size]]: true })}>
         <hx-icon type="checkmark"></hx-icon>
         {icon && (
@@ -58,10 +63,12 @@ ChoiceTile.propTypes = {
   size: PropTypes.oneOf(Object.keys(SIZES)),
   subdued: PropTypes.bool,
   title: PropTypes.string.isRequired,
+  radioInput: PropTypes.node,
 };
 
 ChoiceTile.defaultProps = {
   checked: false,
+  size: 'medium',
 };
 
 export default ChoiceTile;

--- a/src/ChoiceTile/stories.js
+++ b/src/ChoiceTile/stories.js
@@ -17,7 +17,6 @@ const SIZES = {
 };
 
 storiesOf('Choice Tile', module).add('All Knobs', () => {
-  let description = text('description', '');
   let title = text('title', '');
   let checked = boolean('checked', false);
   let disabled = boolean('disabled', false);

--- a/src/ChoiceTile/stories.js
+++ b/src/ChoiceTile/stories.js
@@ -52,16 +52,16 @@ storiesOf('Choice Tile', module).add('All Knobs', () => {
         style={{ width: 200, float: 'left' }}
         title={title || defaultTitle}
       >
-        {<p>{description || defaultDescription}</p>}
+        {<p>{'standard choice tile' || defaultDescription}</p>}
       </ChoiceTile>
 
       <ChoiceTile
         icon="bell"
-        name="choiceTileDemo"
+        radioInput={<input type="radio" name="choiceTileDemo" onChange={callback(action('onChange'))} />}
         style={{ marginLeft: 25, width: 200, float: 'left' }}
         title="Other Choice"
       >
-        {<p>{defaultDescription}</p>}
+        {<p>custom radio (see JSX)</p>}
       </ChoiceTile>
     </React.Fragment>
   );

--- a/src/ChoiceTile/stories.js
+++ b/src/ChoiceTile/stories.js
@@ -57,7 +57,9 @@ storiesOf('Choice Tile', module).add('All Knobs', () => {
 
       <ChoiceTile
         icon="bell"
-        radioInput={<input type="radio" name="choiceTileDemo" onChange={callback(action('onChange'))} />}
+        radioInput={
+          <input type="radio" name="choiceTileDemo" onChange={callback(action('onChange'))} />
+        }
         style={{ marginLeft: 25, width: 200, float: 'left' }}
         title="Other Choice"
       >

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -2,16 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { wcBool } from '../utils';
 
-const Disclosure = ({ className, ariaControls, ariaExpanded, ...rest }) => {
+const Disclosure = React.forwardRef(({ className, ariaControls, ariaExpanded, ...rest }, ref) => {
   return (
     <hx-disclosure
+      ref={ref}
       class={className}
       aria-controls={ariaControls}
       aria-expanded={wcBool(ariaExpanded)}
       {...rest}
     />
   );
-};
+});
 
 Disclosure.propTypes = {
   ariaControls: PropTypes.string.isRequired,
@@ -21,5 +22,7 @@ Disclosure.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
 };
+
+Disclosure.displayName = 'Disclosure';
 
 export default Disclosure;

--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -6,20 +6,24 @@ import { SIZES } from '../constants';
 import useEventListener from '../hooks/useEventListener';
 import { wcBool } from '../utils';
 
-const Drawer = ({ children, className, id, onClose, onOpen, open, size, ...rest }) => {
-  const hxRef = useEventListener({ onOpen, onClose });
-  return (
-    <hx-drawer
-      class={classnames(className, SIZES[size])}
-      id={id}
-      open={wcBool(open)}
-      ref={hxRef}
-      {...rest}
-    >
-      {children}
-    </hx-drawer>
-  );
-};
+const Drawer = React.forwardRef(
+  ({ children, className, id, onClose, onOpen, open, size, ...rest }, ref) => {
+    const hxRef = useEventListener({ onOpen, onClose }, ref);
+    return (
+      <hx-drawer
+        class={classnames(className, SIZES[size])}
+        id={id}
+        open={wcBool(open)}
+        ref={hxRef}
+        {...rest}
+      >
+        {children}
+      </hx-drawer>
+    );
+  }
+);
+
+Drawer.displayName = 'Drawer';
 
 Drawer.propTypes = {
   className: PropTypes.string,

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 export const Icons = Object.keys(HelixUI.Utils.ICONS);
 
 const Icon = ({ type, className, ...rest }) => {
-  return <hx-icon type={type} {...rest} class={className}></hx-icon>;
+  return <hx-icon type={type} {...rest} class={className} />;
 };
 
 Icon.propTypes = {

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,18 +1,27 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import useEventListener from '../hooks/useEventListener';
 import { SIZES } from '../constants';
 import { wcBool } from '../utils';
 
-const Modal = ({ onOpen, onClose, className, open, size, children, ...rest }) => {
-  const hxRef = useEventListener({ onOpen, onClose });
-  return (
-    <hx-modal class={classNames(className, SIZES[size])} ref={hxRef} open={wcBool(open)} {...rest}>
-      {children}
-    </hx-modal>
-  );
-};
+const Modal = React.forwardRef(
+  ({ onOpen, onClose, className, open, size, children, ...rest }, ref) => {
+    const hxRef = useEventListener({ onOpen, onClose }, ref);
+    return (
+      <hx-modal
+        class={classNames(className, SIZES[size])}
+        ref={hxRef}
+        open={wcBool(open)}
+        {...rest}
+      >
+        {children}
+      </hx-modal>
+    );
+  }
+);
+
+Modal.displayName = 'Modal';
 
 Modal.propTypes = {
   id: PropTypes.string,

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -29,7 +29,7 @@ storiesOf('Modal', module).add('All Knobs', () => {
   const longText = [1, 2, 3, 4, 5].map(() => <p>{getLongText()}</p>);
   const defaultFooter = [
     <Button variant="primary">Confirm</Button>,
-    <Button variant="tertiary">Cancel</Button>,
+    <Button variant="secondary">Cancel</Button>,
   ];
 
   return (

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -5,29 +5,24 @@ import useEventListener from '../hooks/useEventListener';
 import { POSITIONS } from '../constants';
 import { wcBool } from '../utils';
 
-const Popover = ({
-  onOpen,
-  onClose,
-  onReposition,
-  className,
-  open,
-  children,
-  relativeTo,
-  ...rest
-}) => {
-  const hxRef = useEventListener({ onOpen, onClose, onReposition });
-  return (
-    <hx-popover
-      class={classNames(className)}
-      ref={hxRef}
-      open={wcBool(open)}
-      relative-to={relativeTo}
-      {...rest}
-    >
-      {children}
-    </hx-popover>
-  );
-};
+const Popover = React.forwardRef(
+  ({ onOpen, onClose, onReposition, className, open, children, relativeTo, ...rest }, ref) => {
+    const hxRef = useEventListener({ onOpen, onClose, onReposition }, ref);
+    return (
+      <hx-popover
+        class={classNames(className)}
+        ref={hxRef}
+        open={wcBool(open)}
+        relative-to={relativeTo}
+        {...rest}
+      >
+        {children}
+      </hx-popover>
+    );
+  }
+);
+
+Popover.displayName = 'Popover';
 
 Popover.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/Popover/stories.js
+++ b/src/Popover/stories.js
@@ -26,7 +26,7 @@ storiesOf('Popover', module)
     const longText = [1, 2, 3, 4, 5].map(() => <p>{getLongText()}</p>);
     const defaultFooter = [
       <Button variant="primary">Ok</Button>,
-      <Button variant="tertiary">Cancel</Button>,
+      <Button variant="secondary">Cancel</Button>,
     ];
     return (
       <>

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const Radio = ({ id, label, className, style, ...rest }) => {
+const Radio = React.forwardRef(({ id, label, className, style, ...rest }, ref) => {
   return (
-    <hx-radio-control class={className} style={style}>
+    <hx-radio-control class={className} style={style} ref={ref}>
       <input {...rest} id={id} type="radio" />
       <label htmlFor={id}>
         <hx-radio></hx-radio>
@@ -11,7 +11,7 @@ const Radio = ({ id, label, className, style, ...rest }) => {
       </label>
     </hx-radio-control>
   );
-};
+});
 
 Radio.propTypes = {
   label: PropTypes.string.isRequired,
@@ -25,4 +25,5 @@ Radio.propTypes = {
   onChange: PropTypes.func,
 };
 
+Radio.displayName = 'Radio';
 export default Radio;

--- a/src/Search/index.js
+++ b/src/Search/index.js
@@ -8,65 +8,72 @@ import { useEffectExceptOnMount } from '../hooks/useEffectExceptOnMounted';
 /**
  * @see https://helixdesignsystem.github.io/helix-ui/components/search/
  */
-const Search = ({
-  children,
-  disabled,
-  id,
-  label,
-  className,
-  clearLabel,
-  onClear,
-  optional,
-  required,
-  containerId,
-  value,
-  style,
-  ...rest
-}) => {
-  /**
-   * Show clear icon when value changes programmatically by triggering 'input' event manually.
-   * @see https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js
-   */
-  const inputRef = useRef();
-  useEffectExceptOnMount(() => {
-    const input = inputRef.current;
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype,
-      'value'
-    ).set;
-    nativeInputValueSetter.call(input, value);
-    const ev = new Event('input', { bubbles: true });
-    input.dispatchEvent(ev);
-  }, [value]);
+const Search = React.forwardRef(
+  (
+    {
+      children,
+      disabled,
+      id,
+      label,
+      className,
+      clearLabel,
+      onClear,
+      optional,
+      required,
+      containerId,
+      value,
+      style,
+      ...rest
+    },
+    ref
+  ) => {
+    /**
+     * Show clear icon when value changes programmatically by triggering 'input' event manually.
+     * @see https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js
+     */
+    const inputRef = useRef();
+    useEffectExceptOnMount(() => {
+      const input = inputRef.current;
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value'
+      ).set;
+      nativeInputValueSetter.call(input, value);
+      const ev = new Event('input', { bubbles: true });
+      input.dispatchEvent(ev);
+    }, [value]);
 
-  return (
-    <hx-search-control class={className} id={containerId} style={style}>
-      <input
-        id={id}
-        value={value}
-        ref={inputRef}
-        {...rest}
-        disabled={wcBool(disabled)}
-        type="search"
-      />
-      <button type="button" className="hxClear" aria-label={clearLabel} hidden onClick={onClear}>
-        <Icon type="times" />
-      </button>
-      <hx-search></hx-search>
-      {label && (
-        <label
-          className={classnames({
-            hxOptional: optional,
-            hxRequired: required,
-          })}
-          htmlFor={id}
-        >
-          {label}
-        </label>
-      )}
-    </hx-search-control>
-  );
-};
+    return (
+      <hx-search-control class={className} id={containerId} style={style} ref={ref}>
+        <input
+          id={id}
+          value={value}
+          ref={inputRef}
+          {...rest}
+          disabled={wcBool(disabled)}
+          type="search"
+        />
+        <button type="button" className="hxClear" aria-label={clearLabel} hidden onClick={onClear}>
+          <Icon type="times" />
+        </button>
+        <hx-search></hx-search>
+        {label && (
+          <label
+            className={classnames({
+              hxOptional: optional,
+              hxRequired: required,
+            })}
+            htmlFor={id}
+          >
+            {label}
+          </label>
+        )}
+      </hx-search-control>
+    );
+  }
+);
+
+Search.displayName = 'Search';
 
 Search.propTypes = {
   className: PropTypes.string,

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -2,38 +2,34 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const Select = ({
-  children,
-  className,
-  disabled,
-  id,
-  label,
-  onChange,
-  optional,
-  required,
-  style,
-  ...rest
-}) => {
-  return (
-    <hx-select-control class={className} style={style}>
-      <select id={id} disabled={disabled} onChange={onChange} required={required} {...rest}>
-        {children}
-      </select>
-      <hx-select></hx-select>
-      {label && (
-        <label
-          className={classnames({
-            hxOptional: optional,
-            hxRequired: required,
-          })}
-          htmlFor={id}
-        >
-          {label}
-        </label>
-      )}
-    </hx-select-control>
-  );
-};
+const Select = React.forwardRef(
+  (
+    { children, className, disabled, id, label, onChange, optional, required, style, ...rest },
+    ref
+  ) => {
+    return (
+      <hx-select-control class={className} style={style} ref={ref}>
+        <select id={id} disabled={disabled} onChange={onChange} required={required} {...rest}>
+          {children}
+        </select>
+        <hx-select></hx-select>
+        {label && (
+          <label
+            className={classnames({
+              hxOptional: optional,
+              hxRequired: required,
+            })}
+            htmlFor={id}
+          >
+            {label}
+          </label>
+        )}
+      </hx-select-control>
+    );
+  }
+);
+
+Select.displayName = 'Select';
 
 Select.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/Switch/index.js
+++ b/src/Switch/index.js
@@ -2,16 +2,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const Switch = ({ id, className, onLabel, offLabel, invalid, ...rest }) => {
+const Switch = React.forwardRef(({ id, className, onLabel, offLabel, invalid, ...rest }, ref) => {
   return (
-    <hx-switch-control class={classnames('switch', className)}>
+    <hx-switch-control class={classnames('switch', className)} ref={ref}>
       <input type="checkbox" id={id} {...rest} invalid={invalid?.toString()} />
       <label htmlFor={id}>
         <hx-switch onlabel={onLabel} offlabel={offLabel} aria-labelledby={id} />
       </label>
     </hx-switch-control>
   );
-};
+});
 
 Switch.propTypes = {
   id: PropTypes.string.isRequired,
@@ -30,4 +30,5 @@ Switch.defaultProps = {
   offLabel: '',
 };
 
+Switch.displayName = 'Switch';
 export default Switch;

--- a/src/Text/index.js
+++ b/src/Text/index.js
@@ -2,37 +2,36 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const Text = ({
-  id,
-  label,
-  invalid,
-  className,
-  required,
-  optional,
-  children,
-  prefix,
-  suffix,
-  style,
-  ...rest
-}) => {
-  return (
-    <hx-text-control class={classnames(className, { hxInvalid: invalid })} style={style}>
-      <input {...rest} id={id} required={required} type="text" />
-      <label
-        className={classnames({
-          hxOptional: optional,
-          hxRequired: required,
-        })}
-        htmlFor={id}
+const Text = React.forwardRef(
+  (
+    { id, label, invalid, className, required, optional, children, prefix, suffix, style, ...rest },
+    ref
+  ) => {
+    return (
+      <hx-text-control
+        class={classnames(className, { hxInvalid: invalid })}
+        style={style}
+        ref={ref}
       >
-        {label}
-      </label>
-      {prefix && <span className="hxPrefix">{prefix}</span>}
-      {suffix && <span className="hxSuffix">{suffix}</span>}
-      {children}
-    </hx-text-control>
-  );
-};
+        <input {...rest} id={id} required={required} type="text" />
+        <label
+          className={classnames({
+            hxOptional: optional,
+            hxRequired: required,
+          })}
+          htmlFor={id}
+        >
+          {label}
+        </label>
+        {prefix && <span className="hxPrefix">{prefix}</span>}
+        {suffix && <span className="hxSuffix">{suffix}</span>}
+        {children}
+      </hx-text-control>
+    );
+  }
+);
+
+Text.displayName = 'Text';
 
 Text.propTypes = {
   id: PropTypes.string.isRequired,

--- a/src/TextArea/index.js
+++ b/src/TextArea/index.js
@@ -2,34 +2,34 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const TextArea = ({
-  id,
-  label,
-  className,
-  required,
-  disabled,
-  optional,
-  invalid,
-  children,
-  style,
-  ...rest
-}) => {
-  return (
-    <hx-textarea-control class={classnames(className, { hxInvalid: invalid })} style={style}>
-      <textarea {...rest} id={id} required={required} disabled={disabled} />
-      <label
-        className={classnames({
-          hxOptional: optional,
-          hxRequired: required,
-        })}
-        htmlFor={id}
+const TextArea = React.forwardRef(
+  (
+    { id, label, className, required, disabled, optional, invalid, children, style, ...rest },
+    ref
+  ) => {
+    return (
+      <hx-textarea-control
+        class={classnames(className, { hxInvalid: invalid })}
+        style={style}
+        ref={ref}
       >
-        {label}
-      </label>
-      {children}
-    </hx-textarea-control>
-  );
-};
+        <textarea {...rest} id={id} required={required} disabled={disabled} />
+        <label
+          className={classnames({
+            hxOptional: optional,
+            hxRequired: required,
+          })}
+          htmlFor={id}
+        >
+          {label}
+        </label>
+        {children}
+      </hx-textarea-control>
+    );
+  }
+);
+
+TextArea.displayName = 'TextArea';
 
 TextArea.propTypes = {
   id: PropTypes.string.isRequired,

--- a/src/Toast/index.js
+++ b/src/Toast/index.js
@@ -7,7 +7,7 @@ const Toast = React.forwardRef(
     const hxRef = useEventListener({ onDismiss, onSubmit }, ref);
     return (
       <div>
-        {/* Wrapping element needed: Otherwise when alert removes itself from DOM on close, it will cause error */}
+        {/* Wrapping element needed: Otherwise when hx-toast removes itself from DOM on close, it will cause error */}
         <hx-toast class={className} ref={hxRef} {...rest}>
           {children}
         </hx-toast>

--- a/src/Toast/index.js
+++ b/src/Toast/index.js
@@ -2,17 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import useEventListener from '../hooks/useEventListener';
 
-const Toast = ({ onOpen, onClose, className, children, onDismiss, onSubmit, ...rest }) => {
-  const hxRef = useEventListener({ onDismiss, onSubmit });
-  return (
-    <div>
-      {/* Wrapping element needed: Otherwise when alert removes itself from DOM on close, it will cause error */}
-      <hx-toast class={className} ref={hxRef} {...rest}>
-        {children}
-      </hx-toast>
-    </div>
-  );
-};
+const Toast = React.forwardRef(
+  ({ onOpen, onClose, className, children, onDismiss, onSubmit, ...rest }, ref) => {
+    const hxRef = useEventListener({ onDismiss, onSubmit }, ref);
+    return (
+      <div>
+        {/* Wrapping element needed: Otherwise when alert removes itself from DOM on close, it will cause error */}
+        <hx-toast class={className} ref={hxRef} {...rest}>
+          {children}
+        </hx-toast>
+      </div>
+    );
+  }
+);
+
+Toast.displayName = 'Toast';
 
 Toast.propTypes = {
   className: PropTypes.string,

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -3,14 +3,18 @@ import React from 'react';
 import { POSITIONS } from '../constants';
 import useEventListener from '../hooks/useEventListener';
 
-const Tooltip = ({ children, id, position, onClose, onOpen, onReposition, ...rest }) => {
-  const hxRef = useEventListener({ onClose, onOpen, onReposition });
-  return (
-    <hx-tooltip for={id} position={position} ref={hxRef} {...rest}>
-      {children}
-    </hx-tooltip>
-  );
-};
+const Tooltip = React.forwardRef(
+  ({ children, id, position, onClose, onOpen, onReposition, ...rest }, ref) => {
+    const hxRef = useEventListener({ onClose, onOpen, onReposition }, ref);
+    return (
+      <hx-tooltip for={id} position={position} ref={hxRef} {...rest}>
+        {children}
+      </hx-tooltip>
+    );
+  }
+);
+
+Tooltip.displayName = 'Tooltip';
 
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/Tooltip/stories.js
+++ b/src/Tooltip/stories.js
@@ -6,6 +6,7 @@ import { select, text } from '@storybook/addon-knobs/react';
 import Tooltip from '../Tooltip';
 import { POSITIONS } from '../constants';
 import { callback } from '../storyUtils';
+import Icon from '../Icon';
 
 addParameters({
   jsx: { skip: 3 },
@@ -19,15 +20,18 @@ storiesOf('Tooltip', module)
     let position = select('positions', POSITIONS, 'top-left');
     let content = text('content', 'I am a tool tip');
 
+    const myRef = React.useRef();
+
     return (
       <>
-        <hx-icon id={id} type="help-circle" />
+        <Icon id={id} type="help-circle" />
         <Tooltip
           id={id}
           position={position}
           onOpen={callback(action('onOpen'))}
           onClose={callback(action('onClose'))}
           onReposition={callback(action('onReposition'))}
+          ref={myRef}
         >
           {content}
         </Tooltip>

--- a/src/Tooltip/stories.js
+++ b/src/Tooltip/stories.js
@@ -1,6 +1,5 @@
 import centered from '@storybook/addon-centered/react';
 import { addParameters, storiesOf } from '@storybook/react';
-import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { select, text } from '@storybook/addon-knobs/react';
 import Tooltip from '../Tooltip';
@@ -20,8 +19,6 @@ storiesOf('Tooltip', module)
     let position = select('positions', POSITIONS, 'top-left');
     let content = text('content', 'I am a tool tip');
 
-    const myRef = React.useRef();
-
     return (
       <>
         <Icon id={id} type="help-circle" />
@@ -31,7 +28,6 @@ storiesOf('Tooltip', module)
           onOpen={callback(action('onOpen'))}
           onClose={callback(action('onClose'))}
           onReposition={callback(action('onReposition'))}
-          ref={myRef}
         >
           {content}
         </Tooltip>

--- a/src/hooks/useCombinedRefs.js
+++ b/src/hooks/useCombinedRefs.js
@@ -1,0 +1,23 @@
+import React from 'react';
+/**
+ * @see https://laptrinhx.com/reusing-the-ref-from-forwardref-with-react-hooks-3215655428/
+ * @param refs
+ * @return {React.MutableRefObject}
+ */
+export default function useCombinedRefs(...refs) {
+  const targetRef = React.useRef();
+
+  React.useEffect(() => {
+    refs.forEach((ref) => {
+      if (!ref) return;
+
+      if (typeof ref === 'function') {
+        ref(targetRef.current);
+      } else {
+        ref.current = targetRef.current;
+      }
+    });
+  }, [refs]);
+
+  return targetRef;
+}

--- a/src/hooks/useEventListener.js
+++ b/src/hooks/useEventListener.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-
+import useCombinedRefs from './useCombinedRefs';
 const handlerNameToEvent = (handlerName) => handlerName.replace(/^on/, '').toLowerCase();
 
 /**
@@ -9,7 +9,8 @@ const handlerNameToEvent = (handlerName) => handlerName.replace(/^on/, '').toLow
  * @return {React.MutableRefObject}
  */
 function useEventListener(eventHandlers = {}, ref) {
-  const theRef = ref || useRef(null);
+  const theRef = ref ? useCombinedRefs(ref, useRef(null)) : useRef(null);
+
   useEffect(() => {
     Object.entries(eventHandlers).forEach(([handlerName, eventHandler], key) => {
       theRef.current.addEventListener(handlerNameToEvent(handlerName), eventHandler);

--- a/src/hooks/useEventListener.js
+++ b/src/hooks/useEventListener.js
@@ -12,11 +12,11 @@ function useEventListener(eventHandlers = {}, ref) {
   const theRef = ref ? useCombinedRefs(ref, useRef(null)) : useRef(null);
 
   useEffect(() => {
-    Object.entries(eventHandlers).forEach(([handlerName, eventHandler], key) => {
+    Object.entries(eventHandlers).forEach(([handlerName, eventHandler]) => {
       theRef.current.addEventListener(handlerNameToEvent(handlerName), eventHandler);
     });
     return () => {
-      Object.entries(eventHandlers).forEach(([handlerName, eventHandler], key) => {
+      Object.entries(eventHandlers).forEach(([handlerName, eventHandler]) => {
         theRef.current.removeEventListener(handlerNameToEvent(handlerName), eventHandler);
       });
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,6 +2705,11 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@webcomponents/webcomponentsjs@^2.4.3":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz#61b27785a6ad5bfd68fa018201fe418b118cb38d"
+  integrity sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -5472,10 +5477,10 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
 
-helix-ui@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/helix-ui/-/helix-ui-0.24.0.tgz#db5e0c2e4f446192f9277ace0e0e2ded49de7fcd"
-  integrity sha512-vP2t5K9Gj3fdyZvmLobT3FlWU+EDr9J6UhwA6HGQlNmrdA42OeQCzg2I4W2l3a5vtNHQfVvjt4vsURFZ7QO/KA==
+helix-ui@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/helix-ui/-/helix-ui-2.0.0.tgz#763ad0a94b19392f8f82af49cc44e38a9a0870f3"
+  integrity sha512-KK0jff0QA9hPRHyu+MhSCiaALMFpKqz7jqJ8CJcgbtzH9u4EQbBxJdwh/97VpIUwvJKRsdCAsnj115YFsFq2Zw==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
- Update to Helix-UI 2.0
- Switch Modals and Popovers to use secondary button styles
- Add support to pass your own custom radio input as prop, useful for redux-form wrapped input fields.
- Added forwarding of Refs or all components that properties